### PR TITLE
Fixed the typo in listing 2.30, Chapter 2 MEAP v11

### DIFF
--- a/kibana_scripts/ch2_getting_started.txt
+++ b/kibana_scripts/ch2_getting_started.txt
@@ -594,7 +594,7 @@ GET covid/_search
 {
   "size": 0, 
   "aggs": {
-    "total_deaths": {
+    "max_deaths": {
       "max": {
         "field": "deaths"
       }


### PR DESCRIPTION
The custom name for the COVID max metric aggregation query should be "max_deaths", instead of "total_deaths".