### PR TITLE
Delete appendices/Appendix D:

### DIFF
--- a/appendices/Appendix D:
+++ b/appendices/Appendix D:
@@ -1,1 +1,0 @@
-Appenndix D goes here


### PR DESCRIPTION
Delete misnamed empty file to prevent checkout errors on Windows